### PR TITLE
Claim all remaining rewards

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -79,8 +79,8 @@ export default function Home() {
     }
   }
 
-  const claim = async (id, reward) => {
-    const tx = await claimReward(id, account, reward, IncentiveKey)
+  const claim = async (id) => {
+    const tx = await claimReward(id, account, '0', IncentiveKey)
     watchTx(tx.hash, 'Claiming rewards')
   }
 
@@ -277,7 +277,7 @@ export default function Home() {
                                 colorScheme="red"
                                 mr="2"
                                 onClick={() =>
-                                  claim(position.id, position.reward)
+                                  claim(position.id)
                                 }
                               >
                                 Claim


### PR DESCRIPTION
Fixes #4 

If the amount requested is 0, then the staking contract will claim all remaining rewards

https://github.com/Uniswap/v3-staker/blob/main/contracts/UniswapV3Staker.sol#L269

The primary advantage of this is that it won't leave unclaimed rewards from the blocks between when a transaction is signed, and when it is mined.

It also has minor gas savings:

1. Cheaper calldata cost by changing the amount value to 0s
2. Storage refund, by setting the stored "reward" value to 0