### PR TITLE
Fix exiting a pool

### DIFF
--- a/utils/pools.js
+++ b/utils/pools.js
@@ -147,7 +147,7 @@ export const exitPool = async (tokenId, address, amount, program) => {
   const staking = new ethers.Contract(v3Staker.address, v3Staker.abi, signer)
 
   // Estimate & Bump gasLimit by 1.2x
-  const gas = await manager.estimateGas.multicall([approveData, transferData])
+  const gas = await staking.estimateGas.multicall([unstakeData, claimData, withdrawData])
   const gasLimit = Math.ceil(gas.toNumber() * 1.2)
 
   const tx = await staking.multicall([unstakeData, claimData, withdrawData], {


### PR DESCRIPTION
This PR fixes exitPool(), which currently throws an undefined variable error when called